### PR TITLE
Add flatten method

### DIFF
--- a/src/PdfSharp/Pdf.AcroForms/PdfAcroField.cs
+++ b/src/PdfSharp/Pdf.AcroForms/PdfAcroField.cs
@@ -23,7 +23,7 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
@@ -310,6 +310,17 @@ namespace PdfSharp.Pdf.AcroForms
             { }
 
             /// <summary>
+            /// Gets the number of elements in the array.
+            /// </summary>
+            public int Count
+            {
+                get
+                {
+                    return Elements.Count;
+                }
+            }
+
+            /// <summary>
             /// Gets the names of all fields in the collection.
             /// </summary>
             public string[] Names
@@ -442,7 +453,7 @@ namespace PdfSharp.Pdf.AcroForms
         }
 
         /// <summary>
-        /// Predefined keys of this dictionary. 
+        /// Predefined keys of this dictionary.
         /// The description comes from PDF 1.4 Reference.
         /// </summary>
         public class Keys : KeysBase
@@ -497,7 +508,7 @@ namespace PdfSharp.Pdf.AcroForms
             public const string TU = "/TU";
 
             /// <summary>
-            /// (Optional; PDF 1.3) The mapping name to be used when exporting interactive form field 
+            /// (Optional; PDF 1.3) The mapping name to be used when exporting interactive form field
             /// data from the document.
             /// </summary>
             [KeyInfo(KeyType.TextString | KeyType.Optional)]

--- a/src/PdfSharp/Pdf.AcroForms/PdfAcroForm.cs
+++ b/src/PdfSharp/Pdf.AcroForms/PdfAcroForm.cs
@@ -23,14 +23,14 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
 namespace PdfSharp.Pdf.AcroForms
 {
     /// <summary>
-    /// Represents a interactive form (or AcroForm), a collection of fields for 
+    /// Represents a interactive form (or AcroForm), a collection of fields for
     /// gathering information interactively from the user.
     /// </summary>
     public sealed class PdfAcroForm : PdfDictionary
@@ -66,7 +66,7 @@ namespace PdfSharp.Pdf.AcroForms
         PdfAcroField.PdfAcroFieldCollection _fields;
 
         /// <summary>
-        /// Predefined keys of this dictionary. 
+        /// Predefined keys of this dictionary.
         /// The description comes from PDF 1.4 Reference.
         /// </summary>
         public sealed class Keys : KeysBase
@@ -99,7 +99,7 @@ namespace PdfSharp.Pdf.AcroForms
             /// <summary>
             /// (Required if any fields in the document have additional-actions dictionaries
             /// containing a C entry; PDF 1.3) An array of indirect references to field dictionaries
-            /// with calculation actions, defining the calculation order in which their values will 
+            /// with calculation actions, defining the calculation order in which their values will
             /// be recalculated when the value of any field changes.
             /// </summary>
             [KeyInfo(KeyType.Array)]

--- a/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/PdfSharp/Pdf/PdfDocument.cs
@@ -850,9 +850,9 @@ namespace PdfSharp.Pdf
         /// </summary>
         public void Flatten()
         {
-            for (int i = 0; i < AcroForm.Fields.Count; i++)
+            for (int idx = 0; idx < AcroForm.Fields.Count; idx++)
             {
-                AcroForm.Fields[i].ReadOnly = true;
+                AcroForm.Fields[idx].ReadOnly = true;
             }
         }
 

--- a/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/PdfSharp/Pdf/PdfDocument.cs
@@ -23,7 +23,7 @@
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 // THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
@@ -800,7 +800,7 @@ namespace PdfSharp.Pdf
 
         /// <summary>
         /// Creates a new page and adds it to this document.
-        /// Depending of the IsMetric property of the current region the page size is set to 
+        /// Depending of the IsMetric property of the current region the page size is set to
         /// A4 or Letter respectively. If this size is not appropriate it should be changed before
         /// any drawing operations are performed on the page.
         /// </summary>
@@ -846,6 +846,17 @@ namespace PdfSharp.Pdf
         }
 
         /// <summary>
+        /// Flattens a document (make the fields non-editable).
+        /// </summary>
+        public void Flatten()
+        {
+            for (int i = 0; i < AcroForm.Fields.Count; i++)
+            {
+                AcroForm.Fields[i].ReadOnly = true;
+            }
+        }
+
+        /// <summary>
         /// Gets the security handler.
         /// </summary>
         public PdfStandardSecurityHandler SecurityHandler
@@ -878,6 +889,7 @@ namespace PdfSharp.Pdf
         }
 
         //internal static GlobalObjectTable Gob = new GlobalObjectTable();
+
 
         /// <summary>
         /// Gets the ThreadLocalStorage object. It is used for caching objects that should created


### PR DESCRIPTION
This PR creates a method to flatten the document, i.e make all fields non editable. 

I believe this is a desired feature because some users may want to prevent changes after a document is generated by their application.

There are minor blank spaces removal. It was done automatically by Visual Studio. I can remove those if necessary, but it seemed a small issue.
