### PR TITLE
Make at least the Fonts resource public.

### DIFF
--- a/src/PdfSharp/Pdf.Advanced/PdfResources.cs
+++ b/src/PdfSharp/Pdf.Advanced/PdfResources.cs
@@ -185,7 +185,7 @@ namespace PdfSharp.Pdf.Advanced
         /// <summary>
         /// Gets the fonts map.
         /// </summary>
-        internal PdfResourceMap Fonts
+        public PdfResourceMap Fonts
         {
             get { return _fonts ?? (_fonts = (PdfResourceMap)Elements.GetValue(Keys.Font, VCF.Create)); }
         }


### PR DESCRIPTION
This resource is very useful in order to parse strings like `<030000330996EF5A>`.
I would expose all resources, (read-only properties), in this file as but at the very minimum the fonts since they are so important for rendering, decoding and locating text. ;-)