### PR TITLE
made fixes for really broken but readable files.

### DIFF
--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -1075,6 +1075,42 @@ namespace PdfSharp.Pdf.IO
 		/// <returns></returns>
 		private bool IsValidXref()
 		{
+			int length = _lexer.PdfLength;
+			int position = _lexer.Position;
+			// Make sure not inside a stream.
+
+			string content = "";
+			int content_pos = position;
+			while (true)
+			{
+				// look for stream and endstream in 1k chunks.
+				int read_length = Math.Min(1024, length - content_pos);
+				content += _lexer.ReadRawString(content_pos, read_length);
+
+				int ss = content.IndexOf("stream", StringComparison.Ordinal);
+				int es = content.IndexOf("endstream", StringComparison.Ordinal);
+
+				if (ss < es)
+				{
+					// Not inside of stream
+					break;
+				}
+				else if (ss > es)
+				{
+					// inside of stream
+					return false;
+				}
+
+				content_pos = content_pos + read_length;
+				if (content_pos + read_length >= length)
+				{
+					// reached the end of the document without finding either.
+					break;
+				}
+			}
+
+			_lexer.Position = position;
+
 			Symbol symbol = ScanNextToken();
 			if (symbol == Symbol.XRef)
 			{
@@ -1153,7 +1189,7 @@ namespace PdfSharp.Pdf.IO
 						}
 
 						trail_pos = trail_pos + trail_length;
-						if (pos + trail_length > length)
+						if (trail_pos + trail_length >= length)
 						{
 							// No endstream was found.
 							throw new Exception("endstream not found.");

--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -1088,17 +1088,21 @@ namespace PdfSharp.Pdf.IO
 				content += _lexer.ReadRawString(content_pos, read_length);
 
 				int ss = content.IndexOf("stream", StringComparison.Ordinal);
+				int eof = content.IndexOf("%%EOF", StringComparison.Ordinal);
 				int es = content.IndexOf("endstream", StringComparison.Ordinal);
 
-				if (ss < es)
+				int s = Math.Min(ss, eof);
+
+				if (s != es)
 				{
-					// Not inside of stream
-					break;
-				}
-				else if (es != -1 && ss > es)
-				{
-					// inside of stream
-					return false;
+					if (s == -1)
+						return false;
+					else if (es == -1)
+						break;
+					else if (s < es)
+						break;
+					else if (s > es)
+						return false;
 				}
 
 				content_pos = content_pos + read_length;

--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -550,7 +550,12 @@ namespace PdfSharp.Pdf.IO
             return _lexer.ScanNextToken();
         }
 
-        private Symbol ScanNextToken(out string token)
+		private Symbol ScanNextToken(out int position)
+		{
+			return _lexer.ScanNextToken(out position);
+		}
+
+		private Symbol ScanNextToken(out string token)
         {
             Symbol symbol = _lexer.ScanNextToken();
             token = _lexer.Token;
@@ -1031,10 +1036,23 @@ namespace PdfSharp.Pdf.IO
                 throw new Exception("The StartXRef table could not be found, the file cannot be opened.");
 
             ReadSymbol(Symbol.StartXRef);
-            _lexer.Position = ReadInteger();
+			int startxref = _lexer.Position = ReadInteger();
 
-            // Read all trailers.
-            while (true)
+			// Check for valid startxref
+			if (!IsValidXref())
+			{
+				PdfTrailer trailer = TryRecreateXRefTableAndTrailer(_document._irefTable);
+				if (trailer == null)
+					throw new Exception("Could not recreate the xref table or trailer.");
+
+				_document._trailer = trailer;
+				return _document._trailer;
+			}
+
+			_lexer.Position = startxref;
+
+			// Read all trailers.
+			while (true)
             {
                 PdfTrailer trailer = ReadXRefTableAndTrailer(_document._irefTable);
                 // 1st trailer seems to be the best.
@@ -1051,10 +1069,130 @@ namespace PdfSharp.Pdf.IO
             return _document._trailer;
         }
 
-        /// <summary>
-        /// Reads cross reference table(s) and trailer(s).
-        /// </summary>
-        private PdfTrailer ReadXRefTableAndTrailer(PdfCrossReferenceTable xrefTable)
+		/// <summary>
+		/// Checks that the current _lexer location is a valid xref.
+		/// </summary>
+		/// <returns></returns>
+		private bool IsValidXref()
+		{
+			Symbol symbol = ScanNextToken();
+			if (symbol == Symbol.XRef)
+			{
+				return true;
+			}
+
+			if (symbol == Symbol.Integer)
+			{
+				// Just because we have an integer, doesn't mean the startxref is actually valid
+				if (ScanNextToken() == Symbol.Integer && ScanNextToken() == Symbol.Obj)
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private PdfTrailer TryRecreateXRefTableAndTrailer(PdfCrossReferenceTable xrefTable)
+		{
+			// Let's first check for a trailer
+			int length = _lexer.PdfLength;
+
+			int trail_idx;
+			if (length >= 1024)
+			{
+				string trail = _lexer.ReadRawString(length - 1024, 1024);
+				trail_idx = trail.LastIndexOf("trailer", StringComparison.Ordinal);
+				_lexer.Position = length - 1024 + trail_idx;
+			}
+			else
+			{
+				string trail = _lexer.ReadRawString(0, length);
+				trail_idx = trail.LastIndexOf("trailer", StringComparison.Ordinal);
+				_lexer.Position = trail_idx;
+			}
+
+			if (trail_idx == -1)
+				return null; //TODO: Look for compressed xref table that should contain the trailer
+
+			ReadSymbol(Symbol.Trailer);
+			ReadSymbol(Symbol.BeginDictionary);
+			PdfTrailer trailer = new PdfTrailer(_document);
+			ReadDictionary(trailer, false);
+
+			// Recreate the xref table.
+			//
+			// When symbol == Symbol.Obj
+			// [0] - generation
+			// [1] - id
+			TokenInfo[] token_stack = new TokenInfo[2];
+			_lexer.Position = 0;
+			while (true)
+			{
+				Symbol symbol = ScanNextToken(out int position);
+				if (symbol == Symbol.Eof)
+					break;
+
+				// we need to skip over streams entirely
+				if (symbol == Symbol.BeginStream)
+				{
+					// We're not reading any data from the object so wee need to find endstream
+					int pos = _lexer.Position;
+					string trail = "";
+					int trail_pos = pos;
+					while (true)
+					{
+						// look for endstream in 1k chunks.
+						int trail_length = Math.Min(1024, length - trail_pos);
+						trail += _lexer.ReadRawString(trail_pos, trail_length);
+						int stop = trail.IndexOf("endstream", StringComparison.Ordinal);
+						if (stop != -1)
+						{
+							_lexer.Position = stop + pos;
+							break;
+						}
+
+						trail_pos = trail_pos + trail_length;
+						if (pos + trail_length > length)
+						{
+							// No endstream was found.
+							throw new Exception("endstream not found.");
+						}
+					}
+				}
+
+				if (symbol == Symbol.Obj &&
+					token_stack[0].Symbol == Symbol.Integer &&
+					token_stack[1].Symbol == Symbol.Integer)
+				{
+					PdfObjectID objectID = new PdfObjectID(token_stack[1].Number, token_stack[0].Number);
+					if (!xrefTable.Contains(objectID))
+						xrefTable.Add(new PdfReference(objectID, token_stack[1].Position));
+					//ReadObject(null, objectID, false, false); // Can't do this because the object value will never be set after
+					//SkipCharsUntil(Symbol.EndObj); // Can't do this because streams will cause exceptions
+				}
+
+				token_stack[1] = token_stack[0];
+				TokenInfo token_info = new TokenInfo { Symbol = symbol, Position = position };
+				if (symbol == Symbol.Integer)
+					token_info.Number = _lexer.TokenToInteger;
+				token_stack[0] = token_info;
+			}
+
+			return trailer;
+		}
+
+		struct TokenInfo
+		{
+			public int Position;
+			public Symbol Symbol;
+			public int Number;
+		}
+
+		/// <summary>
+		/// Reads cross reference table(s) and trailer(s).
+		/// </summary>
+		private PdfTrailer ReadXRefTableAndTrailer(PdfCrossReferenceTable xrefTable)
         {
             Debug.Assert(xrefTable != null);
 

--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -1095,7 +1095,7 @@ namespace PdfSharp.Pdf.IO
 					// Not inside of stream
 					break;
 				}
-				else if (ss > es)
+				else if (es != -1 && ss > es)
 				{
 					// inside of stream
 					return false;


### PR DESCRIPTION
Can now open and parse files with an incorrect startxref and incorrect stream lengths. Note that adobe acrobat x 10.0.0 will open these files and prompt for save when closed.

When the startxref is incorrect, it looks for the 'trailer' symbol and uses that trailer. Otherwise the xref table is not rebuilt. When the trailer is found, it then parses through the entire file and records the location of each object and places a new PdfReference inside of the PdfCrossReferenceTable.

Will also attempt to correct invalid stream lengths. After the stream length is pulled from the object, we first check for an incorrect 'endstream' symbol. If the 'endstream' symbol is not present where expected, we then look for the next valid 'endstream' symbol after the 'startstream' symbol. We use the 'endstream' symbol index and set the length of the stream.

Note 1: No implementation for a pdf file with a compressed trailer object yet.
Note 2: Not tested with versioned files and will still probably fail.
Note 3: On invalid stream length, should probably check 1k chunks of data for 'endstream'. Currently checks within the invalid length and if not found, loads the rest of the file and checks again.