### PR TITLE
No longer assumes xref object numbers.

### DIFF
--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -1068,20 +1068,26 @@ namespace PdfSharp.Pdf.IO
                     symbol = ScanNextToken();
                     if (symbol == Symbol.Integer)
                     {
-                        int start = _lexer.TokenToInteger;
                         int length = ReadInteger();
-                        for (int id = start; id < start + length; id++)
+                        for (int idx = 0; idx < length; idx++)
                         {
                             int position = ReadInteger();
                             int generation = ReadInteger();
                             ReadSymbol(Symbol.Keyword);
                             string token = _lexer.Token;
                             // Skip start entry
-                            if (id == 0)
+                            if (idx == 0)
                                 continue;
                             // Skip unused entries.
                             if (token != "n")
                                 continue;
+
+							// Some PDF producers don't follow xref specs. Can't assume object number.
+							int pos = _lexer.Position;
+							_lexer.Position = position;
+							int id = ReadInteger();
+							_lexer.Position = pos;
+
                             // Even it is restricted, an object can exists in more than one subsection.
                             // (PDF Reference Implementation Notes 15).
                             PdfObjectID objectID = new PdfObjectID(id, generation);

--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -1075,9 +1075,12 @@ namespace PdfSharp.Pdf.IO
                             int generation = ReadInteger();
                             ReadSymbol(Symbol.Keyword);
                             string token = _lexer.Token;
+
+							// Start entry should be marked as free.
                             // Skip start entry
-                            if (idx == 0)
-                                continue;
+                            //if (idx == 0)
+                            //    continue;
+
                             // Skip unused entries.
                             if (token != "n")
                                 continue;


### PR DESCRIPTION
Some PDF Producers get the xref object numbering wrong. As such, object numbers are no longer assumed and retrieved from the object itself.