### PR TITLE
Fix: width of axis title when orientation != 0

### DIFF
--- a/src/PdfSharp.Charting/Charting.Renderers/AxisTitleRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/AxisTitleRenderer.cs
@@ -91,7 +91,8 @@ namespace PdfSharp.Charting.Renderers
                 XGraphics gfx = _rendererParms.Graphics;
                 if (atri.AxisTitleOrientation != 0)
                 {
-                    XRect layout = atri.Rect;
+                    XRect layout = new XRect(new XPoint(0, 0), gfx.MeasureString(atri.AxisTitleText, atri.AxisTitleFont));
+                    layout.Height = atri.Rect.Height;
                     layout.X = -(layout.Width / 2);
                     layout.Y = -(layout.Height / 2);
 


### PR DESCRIPTION
Width of axis title is incorrect when orientation != 0.
![image](https://user-images.githubusercontent.com/914224/33243176-e3d4edfe-d302-11e7-81b2-2e65cf5a8c55.png)

After fix:
![image](https://user-images.githubusercontent.com/914224/33243301-4a39d0da-d305-11e7-8792-915ad028eca9.png)
