### PR TITLE
Allow /Filter value to be a indirect object.

### DIFF
--- a/src/PdfSharp/Pdf.Filters/Filtering.cs
+++ b/src/PdfSharp/Pdf.Filters/Filtering.cs
@@ -27,6 +27,7 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using PdfSharp.Pdf.Advanced;
 using System;
 using System.Diagnostics;
 
@@ -201,6 +202,12 @@ namespace PdfSharp.Pdf.Filters
         public static byte[] Decode(byte[] data, PdfItem filterItem)
         {
             byte[] result = null;
+            if (filterItem is PdfReference)
+            {
+                PdfReference iref = (PdfReference)filterItem;
+                Debug.Assert(iref.Value != null, "Indirect /Filter value is null");
+                filterItem = iref.Value;
+            }
             if (filterItem is PdfName)
             {
                 Filter filter = GetFilter(filterItem.ToString());


### PR DESCRIPTION
Cases where the /Filter value is an iref the filter lookup would search for "18 0 R" and fail to process content. This was seen with filter array values in a PDF-1.3.