### PR TITLE
Make it possible to provide custom XMP metadata

### DIFF
--- a/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/PdfSharp/Pdf/PdfDocument.cs
@@ -491,7 +491,10 @@ namespace PdfSharp.Pdf
             
             // @PDF/UA
             // Create PdfMetadata now to include the final document information in XMP generation.
-            Catalog.Elements.SetReference(PdfCatalog.Keys.Metadata, new PdfMetadata(this));
+			if( MetadataProvider != null )
+	            Catalog.Elements.SetReference(PdfCatalog.Keys.Metadata, MetadataProvider(this));
+			else
+	            Catalog.Elements.SetReference(PdfCatalog.Keys.Metadata, new PdfMetadata(this));
         }
 
         /// <summary>
@@ -807,6 +810,13 @@ namespace PdfSharp.Pdf
             get { return _catalog ?? (_catalog = _trailer.Root); }
         }
         PdfCatalog _catalog;  // never changes if once created
+
+		public delegate PdfMetadata PdfMetadataProvider(PdfDocument document);
+
+		/// <summary>
+		/// Gets or sets the delegate that will return the PdfMetadata object to use when saving the document
+		/// </summary>
+		public PdfMetadataProvider MetadataProvider { get; set; }
 
         /// <summary>
         /// Gets the PdfInternals object of this document, that grants access to some internal structures

--- a/src/PdfSharp/Pdf/PdfMetadata.cs
+++ b/src/PdfSharp/Pdf/PdfMetadata.cs
@@ -35,7 +35,7 @@ namespace PdfSharp.Pdf
     /// <summary>
     /// Represents an XML Metadata stream.
     /// </summary>
-    public sealed class PdfMetadata : PdfDictionary
+    public class PdfMetadata : PdfDictionary
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PdfMetadata"/> class.
@@ -60,15 +60,15 @@ namespace PdfSharp.Pdf
             SetupStream();
         }
 
-        void SetupStream()
+        protected void SetupStream()
         {
             var stream = GenerateXmp();
             
-            byte[] bytes = PdfEncoders.RawEncoding.GetBytes(stream);
-            CreateStream(bytes);
+			if(stream != null)
+	            CreateStream(stream);
         }
 
-        string GenerateXmp()
+        protected virtual byte[] GenerateXmp()
         {
             var instanceId = Guid.NewGuid().ToString();
             var documentId = Guid.NewGuid().ToString();
@@ -123,7 +123,7 @@ namespace PdfSharp.Pdf
             "    </x:xmpmeta>\n" +
             "<?xpacket end=\"r\"?>\n";
 
-            return str;
+            return PdfEncoders.RawEncoding.GetBytes(str);
         }
 
         /// <summary>


### PR DESCRIPTION
The PdfMetadata class is now inheritable. PdfDocument has a new delegate that can be used to provide a different implementation of that class that creates custom metadata.

e.g.:

	class MyXMPMetadata : PdfMetadata
	{
		private readonly XmpCore	xmp;

		public MyXMPMetadata( PdfDocument document, XmpCore xmpCore ) : base( document )
		{
			xmp = xmpCore;

			SetupStream();
		}

		protected override byte[] GenerateXmp()
		{
			return xmp?.SerializeToRDF();
		}
	}