### PR TITLE
Fix Name setter for Pdf.Contents.Objects.CName

### DIFF
--- a/src/PdfSharp/Pdf.Content.Objects/CObjects.cs
+++ b/src/PdfSharp/Pdf.Content.Objects/CObjects.cs
@@ -773,7 +773,7 @@ namespace PdfSharp.Pdf.Content.Objects  // TODO: split into single files
             {
                 if (String.IsNullOrEmpty(value))
                     throw new ArgumentNullException(nameof(value));
-                if (_name[0] != '/')
+                if (value[0] != '/')
                     throw new ArgumentException(PSSR.NameMustStartWithSlash);
                 _name = value;
             }

--- a/src/PdfSharp/Pdf.Content.Objects/CObjects.cs
+++ b/src/PdfSharp/Pdf.Content.Objects/CObjects.cs
@@ -771,7 +771,7 @@ namespace PdfSharp.Pdf.Content.Objects  // TODO: split into single files
             get { return _name; }
             set
             {
-                if (String.IsNullOrEmpty(_name))
+                if (String.IsNullOrEmpty(value))
                     throw new ArgumentNullException(nameof(value));
                 if (_name[0] != '/')
                     throw new ArgumentException(PSSR.NameMustStartWithSlash);


### PR DESCRIPTION
The setter should be validating the input, not the existing value.
As is, the CName(string name) constructor always throws an ArgumentNullException.