### PR TITLE
Fix InsertRange annotation crash

### DIFF
--- a/src/PdfSharp/Pdf/PdfPages.cs
+++ b/src/PdfSharp/Pdf/PdfPages.cs
@@ -360,7 +360,7 @@ namespace PdfSharp.Pdf
                     if (annotations.Count > 0)
                     {
                         //Owner._irefTable.Add(annotations);
-                        page.Elements.Add(PdfPage.Keys.Annots, annotations);
+                        page.Elements[PdfPage.Keys.Annots] = annotations;
                     }
                 }
 


### PR DESCRIPTION
PdfSharp.Pdf.InsertRange crash if there is fixed annotations.

Crash happen at the end of PdfSharp.Pdf.InsertRange:
`page.Elements.Add(PdfPage.Keys.Annots, annotations);`
since page have already annotations added by ImportExternalPage method. Therefore this seems like potential regression bug.

So use replace instead? Works nicely for me but I have no enough knowledge about PDF format to say should annotations be merged mode intelligently instead?