### PR TITLE
Read and correct corrupt PDFs with incorrect stream lengths

### DIFF
--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -283,8 +283,16 @@ namespace PdfSharp.Pdf.IO
         {
             Symbol symbol = _lexer.Symbol;
             Debug.Assert(symbol == Symbol.BeginStream);
+
             int length = GetStreamLength(dict);
             byte[] bytes = _lexer.ReadStream(length);
+
+            if (bytes.Length != length)
+            {
+                // The file is corrupted, but still readable.
+                dict.Elements["/Length"] = new PdfInteger(bytes.Length);
+            }
+
             PdfDictionary.PdfStream stream = new PdfDictionary.PdfStream(bytes, dict);
             Debug.Assert(dict.Stream == null, "Dictionary already has a stream.");
             dict.Stream = stream;

--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -266,41 +266,8 @@ namespace PdfSharp.Pdf.IO
             {
                 PdfDictionary dict = (PdfDictionary)pdfObject;
                 Debug.Assert(checkForStream, "Unexpected stream...");
-#if true_
                 ReadStream(dict);
-#else
-                int length = GetStreamLength(dict);
-                byte[] bytes = _lexer.ReadStream(length);
-#if true_
-                if (dict.Elements.GetString("/Filter") == "/FlateDecode")
-                {
-                    if (dict.Elements["/Subtype"] == null)
-                    {
-                        try
-                        {
-                            byte[] decoded = Filtering.FlateDecode.Decode(bytes);
-                            if (decoded.Length == 0)
-                                goto End;
-                            string pageContent = Filtering.FlateDecode.DecodeToString(bytes);
-                            if (pageContent.Length > 100)
-                                pageContent = pageContent.Substring(pageContent.Length - 100);
-                            pageContent.GetType();
-                            bytes = decoded;
-                            dict.Elements.Remove("/Filter");
-                            dict.Elements.SetInteger("/Length", bytes.Length);
-                        }
-                        catch
-                        {
-                        }
-                    }
-                End: ;
-                }
-#endif
-                PdfDictionary.PdfStream stream = new PdfDictionary.PdfStream(bytes, dict);
-                dict.Stream = stream;
-                ReadSymbol(Symbol.EndStream);
-                symbol = ScanNextToken();
-#endif
+                symbol = _lexer.Symbol;
             }
             if (!fromObjecStream && symbol != Symbol.EndObj)
                 ParserDiagnostics.ThrowParserException(PSSR.UnexpectedToken(_lexer.Token));


### PR DESCRIPTION
If a stream specifies a length that does not match its actual value, PDFsharp would previously read past the "endstream" marker and fail to parse the rest of the file. This change allows PDFsharp to read the stream properly, even if the length is incorrect. The correct length is then written back into the stream's dictionary. Much of these changes come from @MLaukala who originally wrote the read stream logic.