### PR TITLE
Allow uints(PdfUInteger) when calling ReadInt to support some encrypted file header reading

### DIFF
--- a/src/PdfSharp/Pdf/PdfDictionary.cs
+++ b/src/PdfSharp/Pdf/PdfDictionary.cs
@@ -407,7 +407,10 @@ namespace PdfSharp.Pdf
                 if (integerObject != null)
                     return integerObject.Value;
 
-                throw new InvalidCastException("GetInteger: Object is not an integer.");
+				PdfUInteger uinteger = obj as PdfUInteger;
+				if (uinteger != null)
+					return (int)uinteger.Value;
+				throw new InvalidCastException("GetInteger: Object is not an integer.");
             }
 
             /// <summary>


### PR DESCRIPTION
This allows reading of uints by ReadInt and converts them to negative integers. This allows for reading some headers with other encryption options, even if we don't support that encryption type (useful if pdf still has read access without). Should not break most existing code unless code expected an exception for reading uints and was catching it.

Could look at adding a ReadUInt as well and changing the header functionality depending on preferences but as this allowed reading these PDF's it seemed acceptable to me as is (with in theory low possible side effects).