### PR TITLE
Ability to add slant to chart axis tick labels

### DIFF
--- a/src/PdfSharp-gdi/PdfSharp-gdi.csproj
+++ b/src/PdfSharp-gdi/PdfSharp-gdi.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -29,7 +29,7 @@
     <SignAssembly>true</SignAssembly>
     <OldToolsVersion>3.5</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -44,10 +44,10 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-        <SccProjectName>SAK</SccProjectName>
-        <SccLocalPath>SAK</SccLocalPath>
-        <SccAuxPath>SAK</SccAuxPath>
-        <SccProvider>SAK</SccProvider>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -74,6 +74,7 @@
     <ErrorReport>prompt</ErrorReport>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -97,6 +98,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>none</DebugType>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">
@@ -362,9 +364,9 @@
     <Compile Include="..\PdfSharp\Drawing\XGlyphTypeface.cs">
       <Link>Drawing\XGlyphTypeface.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Drawing\XGradientBrush.cs">
-            <Link>Drawing\XGradientBrush.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Drawing\XGradientBrush.cs">
+      <Link>Drawing\XGradientBrush.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Drawing\XGraphics.cs">
       <Link>Drawing\XGraphics.cs</Link>
     </Compile>
@@ -413,9 +415,9 @@
     <Compile Include="..\PdfSharp\Drawing\XPrivateFontCollection.cs">
       <Link>Drawing\XPrivateFontCollection.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Drawing\XRadialGradientBrush.cs">
-            <Link>Drawing\XRadialGradientBrush.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Drawing\XRadialGradientBrush.cs">
+      <Link>Drawing\XRadialGradientBrush.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Drawing\XRect.cs">
       <Link>Drawing\XRect.cs</Link>
     </Compile>
@@ -440,9 +442,9 @@
     <Compile Include="..\PdfSharp\Drawing\XVector.cs">
       <Link>Drawing\XVector.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Events\DocumentEvents.cs">
-            <Link>Events\DocumentEvents.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Events\DocumentEvents.cs">
+      <Link>Events\DocumentEvents.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Fonts.OpenType\enums\FontTechnology.cs">
       <Link>Fonts.OpenType\enums\FontTechnology.cs</Link>
     </Compile>
@@ -614,12 +616,12 @@
     <Compile Include="..\PdfSharp\Pdf.Actions\PdfAction.cs">
       <Link>Pdf.Actions\PdfAction.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Actions\PdfEmbeddedGoToAction.cs">
-            <Link>Pdf.Actions\PdfEmbeddedGoToAction.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Actions\PdfRemoteGoToAction.cs">
-            <Link>Pdf.Actions\PdfRemoteGoToAction.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Actions\PdfEmbeddedGoToAction.cs">
+      <Link>Pdf.Actions\PdfEmbeddedGoToAction.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Actions\PdfRemoteGoToAction.cs">
+      <Link>Pdf.Actions\PdfRemoteGoToAction.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Actions\PdfGoToAction.cs">
       <Link>Pdf.Actions\PdfGoToAction.cs</Link>
     </Compile>
@@ -647,18 +649,18 @@
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfDictionaryWithContentStream.cs">
       <Link>Pdf.Advanced\PdfDictionaryWithContentStream.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfEmbeddedFileStream.cs">
-            <Link>Pdf.Advanced\PdfEmbeddedFileStream.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfEmbeddedFileStream.cs">
+      <Link>Pdf.Advanced\PdfEmbeddedFileStream.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfExtGState.cs">
       <Link>Pdf.Advanced\PdfExtGState.cs</Link>
     </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfExtGStateTable.cs">
       <Link>Pdf.Advanced\PdfExtGStateTable.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfFileSpecification.cs">
-            <Link>Pdf.Advanced\PdfFileSpecification.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfFileSpecification.cs">
+      <Link>Pdf.Advanced\PdfFileSpecification.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfFont.cs">
       <Link>Pdf.Advanced\PdfFont.cs</Link>
     </Compile>
@@ -692,12 +694,12 @@
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfInternals.cs">
       <Link>Pdf.Advanced\PdfInternals.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNamedDestinationParameters.cs">
-            <Link>Pdf.Advanced\PdfNamedDestinationParameters.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNameDictionary.cs">
-            <Link>Pdf.Advanced\PdfNameDictionary.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNamedDestinationParameters.cs">
+      <Link>Pdf.Advanced\PdfNamedDestinationParameters.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNameDictionary.cs">
+      <Link>Pdf.Advanced\PdfNameDictionary.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfObjectInternals.cs">
       <Link>Pdf.Advanced\PdfObjectInternals.cs</Link>
     </Compile>
@@ -920,30 +922,30 @@
     <Compile Include="..\PdfSharp\Pdf.Security\PdfStandardSecurityHandler.cs">
       <Link>Pdf.Security\PdfStandardSecurityHandler.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfAttributesBase.cs">
-            <Link>Pdf.Structure\PdfAttributesBase.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfLayoutAttributes.cs">
-            <Link>Pdf.Structure\PdfLayoutAttributes.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkedContentReference.cs">
-            <Link>Pdf.Structure\PdfMarkedContentReference.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkInformation.cs">
-            <Link>Pdf.Structure\PdfMarkInformation.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfObjectReference.cs">
-            <Link>Pdf.Structure\PdfObjectReference.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureElement.cs">
-            <Link>Pdf.Structure\PdfStructureElement.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureTreeRoot.cs">
-            <Link>Pdf.Structure\PdfStructureTreeRoot.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfTableAttributes.cs">
-            <Link>Pdf.Structure\PdfTableAttributes.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfAttributesBase.cs">
+      <Link>Pdf.Structure\PdfAttributesBase.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfLayoutAttributes.cs">
+      <Link>Pdf.Structure\PdfLayoutAttributes.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkedContentReference.cs">
+      <Link>Pdf.Structure\PdfMarkedContentReference.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkInformation.cs">
+      <Link>Pdf.Structure\PdfMarkInformation.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfObjectReference.cs">
+      <Link>Pdf.Structure\PdfObjectReference.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureElement.cs">
+      <Link>Pdf.Structure\PdfStructureElement.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureTreeRoot.cs">
+      <Link>Pdf.Structure\PdfStructureTreeRoot.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfTableAttributes.cs">
+      <Link>Pdf.Structure\PdfTableAttributes.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\EntryInfoAttribute.cs">
       <Link>Pdf\EntryInfoAttribute.cs</Link>
     </Compile>
@@ -1007,9 +1009,9 @@
     <Compile Include="..\PdfSharp\Pdf\PdfCustomValues.cs">
       <Link>Pdf\PdfCustomValues.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf\PdfNameTreeNode.cs">
-            <Link>Pdf\PdfNameTreeNode.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf\PdfNameTreeNode.cs">
+      <Link>Pdf\PdfNameTreeNode.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\PdfDate.cs">
       <Link>Pdf\PdfDate.cs</Link>
     </Compile>
@@ -1040,9 +1042,9 @@
     <Compile Include="..\PdfSharp\Pdf\PdfLiteral.cs">
       <Link>Pdf\PdfLiteral.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf\PdfMetadata.cs">
-            <Link>Pdf\PdfMetadata.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf\PdfMetadata.cs">
+      <Link>Pdf\PdfMetadata.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\PdfName.cs">
       <Link>Pdf\PdfName.cs</Link>
     </Compile>
@@ -1061,9 +1063,9 @@
     <Compile Include="..\PdfSharp\Pdf\PdfNumberObject.cs">
       <Link>Pdf\PdfNumberObject.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf\PdfNumberTreeNode.cs">
-            <Link>Pdf\PdfNumberTreeNode.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf\PdfNumberTreeNode.cs">
+      <Link>Pdf\PdfNumberTreeNode.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\PdfObject.cs">
       <Link>Pdf\PdfObject.cs</Link>
     </Compile>

--- a/src/PdfSharp-wpf/PdfSharp-wpf.csproj
+++ b/src/PdfSharp-wpf/PdfSharp-wpf.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PdfSharp</RootNamespace>
     <AssemblyName>PdfSharp-wpf</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>StrongnameKey.snk</AssemblyOriginatorKeyFile>
@@ -33,10 +33,10 @@
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-        <SccProjectName>SAK</SccProjectName>
-        <SccLocalPath>SAK</SccLocalPath>
-        <SccAuxPath>SAK</SccAuxPath>
-        <SccProvider>SAK</SccProvider>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>
@@ -331,9 +331,9 @@
     <Compile Include="..\PdfSharp\Drawing\XGlyphTypeface.cs">
       <Link>Drawing\XGlyphTypeface.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Drawing\XGradientBrush.cs">
-            <Link>Drawing\XGradientBrush.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Drawing\XGradientBrush.cs">
+      <Link>Drawing\XGradientBrush.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Drawing\XGraphics.cs">
       <Link>Drawing\XGraphics.cs</Link>
     </Compile>
@@ -382,9 +382,9 @@
     <Compile Include="..\PdfSharp\Drawing\XPrivateFontCollection.cs">
       <Link>Drawing\XPrivateFontCollection.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Drawing\XRadialGradientBrush.cs">
-            <Link>Drawing\XRadialGradientBrush.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Drawing\XRadialGradientBrush.cs">
+      <Link>Drawing\XRadialGradientBrush.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Drawing\XRect.cs">
       <Link>Drawing\XRect.cs</Link>
     </Compile>
@@ -409,9 +409,9 @@
     <Compile Include="..\PdfSharp\Drawing\XVector.cs">
       <Link>Drawing\XVector.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Events\DocumentEvents.cs">
-            <Link>Events\DocumentEvents.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Events\DocumentEvents.cs">
+      <Link>Events\DocumentEvents.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Fonts.OpenType\enums\FontTechnology.cs">
       <Link>Fonts.OpenType\enums\FontTechnology.cs</Link>
     </Compile>
@@ -562,12 +562,12 @@
     <Compile Include="..\PdfSharp\Pdf.Actions\PdfAction.cs">
       <Link>Pdf.Actions\PdfAction.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Actions\PdfEmbeddedGoToAction.cs">
-            <Link>Pdf.Actions\PdfEmbeddedGoToAction.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Actions\PdfRemoteGoToAction.cs">
-            <Link>Pdf.Actions\PdfRemoteGoToAction.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Actions\PdfEmbeddedGoToAction.cs">
+      <Link>Pdf.Actions\PdfEmbeddedGoToAction.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Actions\PdfRemoteGoToAction.cs">
+      <Link>Pdf.Actions\PdfRemoteGoToAction.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Actions\PdfGoToAction.cs">
       <Link>Pdf.Actions\PdfGoToAction.cs</Link>
     </Compile>
@@ -595,18 +595,18 @@
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfDictionaryWithContentStream.cs">
       <Link>Pdf.Advanced\PdfDictionaryWithContentStream.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfEmbeddedFileStream.cs">
-            <Link>Pdf.Advanced\PdfEmbeddedFileStream.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfEmbeddedFileStream.cs">
+      <Link>Pdf.Advanced\PdfEmbeddedFileStream.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfExtGState.cs">
       <Link>Pdf.Advanced\PdfExtGState.cs</Link>
     </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfExtGStateTable.cs">
       <Link>Pdf.Advanced\PdfExtGStateTable.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfFileSpecification.cs">
-            <Link>Pdf.Advanced\PdfFileSpecification.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfFileSpecification.cs">
+      <Link>Pdf.Advanced\PdfFileSpecification.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfFont.cs">
       <Link>Pdf.Advanced\PdfFont.cs</Link>
     </Compile>
@@ -640,12 +640,12 @@
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfInternals.cs">
       <Link>Pdf.Advanced\PdfInternals.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNamedDestinationParameters.cs">
-            <Link>Pdf.Advanced\PdfNamedDestinationParameters.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNameDictionary.cs">
-            <Link>Pdf.Advanced\PdfNameDictionary.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNamedDestinationParameters.cs">
+      <Link>Pdf.Advanced\PdfNamedDestinationParameters.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Advanced\PdfNameDictionary.cs">
+      <Link>Pdf.Advanced\PdfNameDictionary.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf.Advanced\PdfObjectInternals.cs">
       <Link>Pdf.Advanced\PdfObjectInternals.cs</Link>
     </Compile>
@@ -865,30 +865,30 @@
     <Compile Include="..\PdfSharp\Pdf.Security\PdfStandardSecurityHandler.cs">
       <Link>Pdf.Security\PdfStandardSecurityHandler.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfAttributesBase.cs">
-            <Link>Pdf.Structure\PdfAttributesBase.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfLayoutAttributes.cs">
-            <Link>Pdf.Structure\PdfStructureElement.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkedContentReference.cs">
-            <Link>Pdf.Structure\PdfMarkedContentReference.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkInformation.cs">
-            <Link>Pdf.Structure\PdfMarkInformation.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfObjectReference.cs">
-            <Link>Pdf.Structure\PdfObjectReference.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureElement.cs">
-            <Link>Pdf.Structure\PdfStructureElement.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureTreeRoot.cs">
-            <Link>Pdf.Structure\PdfStructureTreeRoot.cs</Link>
-        </Compile>
-        <Compile Include="..\PdfSharp\Pdf.Structure\PdfTableAttributes.cs">
-            <Link>Pdf.Structure\PdfTableAttributes.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfAttributesBase.cs">
+      <Link>Pdf.Structure\PdfAttributesBase.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfLayoutAttributes.cs">
+      <Link>Pdf.Structure\PdfStructureElement.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkedContentReference.cs">
+      <Link>Pdf.Structure\PdfMarkedContentReference.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfMarkInformation.cs">
+      <Link>Pdf.Structure\PdfMarkInformation.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfObjectReference.cs">
+      <Link>Pdf.Structure\PdfObjectReference.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureElement.cs">
+      <Link>Pdf.Structure\PdfStructureElement.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfStructureTreeRoot.cs">
+      <Link>Pdf.Structure\PdfStructureTreeRoot.cs</Link>
+    </Compile>
+    <Compile Include="..\PdfSharp\Pdf.Structure\PdfTableAttributes.cs">
+      <Link>Pdf.Structure\PdfTableAttributes.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\EntryInfoAttribute.cs">
       <Link>Pdf\EntryInfoAttribute.cs</Link>
     </Compile>
@@ -952,9 +952,9 @@
     <Compile Include="..\PdfSharp\Pdf\PdfCustomValues.cs">
       <Link>Pdf\PdfCustomValues.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf\PdfNameTreeNode.cs">
-            <Link>Pdf\PdfNameTreeNode.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf\PdfNameTreeNode.cs">
+      <Link>Pdf\PdfNameTreeNode.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\PdfDate.cs">
       <Link>Pdf\PdfDate.cs</Link>
     </Compile>
@@ -985,9 +985,9 @@
     <Compile Include="..\PdfSharp\Pdf\PdfLiteral.cs">
       <Link>Pdf\PdfLiteral.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf\PdfMetadata.cs">
-            <Link>Pdf\PdfMetadata.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf\PdfMetadata.cs">
+      <Link>Pdf\PdfMetadata.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\PdfName.cs">
       <Link>Pdf\PdfName.cs</Link>
     </Compile>
@@ -1006,9 +1006,9 @@
     <Compile Include="..\PdfSharp\Pdf\PdfNumberObject.cs">
       <Link>Pdf\PdfNumberObject.cs</Link>
     </Compile>
-        <Compile Include="..\PdfSharp\Pdf\PdfNumberTreeNode.cs">
-            <Link>Pdf\PdfNumberTreeNode.cs</Link>
-        </Compile>
+    <Compile Include="..\PdfSharp\Pdf\PdfNumberTreeNode.cs">
+      <Link>Pdf\PdfNumberTreeNode.cs</Link>
+    </Compile>
     <Compile Include="..\PdfSharp\Pdf\PdfObject.cs">
       <Link>Pdf\PdfObject.cs</Link>
     </Compile>

--- a/src/PdfSharp.Charting-gdi/PdfSharp.Charting-gdi.csproj
+++ b/src/PdfSharp.Charting-gdi/PdfSharp.Charting-gdi.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -28,7 +28,7 @@
     </UpgradeBackupLocation>
     <SignAssembly>true</SignAssembly>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -73,6 +73,7 @@
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -96,6 +97,7 @@
     <DebugType>none</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">

--- a/src/PdfSharp.Charting-wpf/PdfSharp.Charting-wpf.csproj
+++ b/src/PdfSharp.Charting-wpf/PdfSharp.Charting-wpf.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.30729</ProductVersion>
@@ -28,7 +28,7 @@
     </UpgradeBackupLocation>
     <SignAssembly>true</SignAssembly>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -72,6 +72,7 @@
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -95,6 +96,7 @@
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationCore" />

--- a/src/PdfSharp.Charting/Charting.Renderers/HorizontalXAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/HorizontalXAxisRenderer.cs
@@ -143,7 +143,11 @@ namespace PdfSharp.Charting.Renderers
                     {
                         string tickLabel = xv._value;
                         XSize size = gfx.MeasureString(tickLabel, xari.TickLabelsFont);
-                        gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, startPos.X - size.Width / 2, startPos.Y);
+                        var point = new XPoint(startPos.X - size.Width / 2, startPos.Y);
+                        double rotateAngle = xari._axis.TickLabelAngle;
+                        gfx.RotateAtTransform(rotateAngle, point);
+                        gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, point);
+                        gfx.RotateAtTransform(-rotateAngle, point);
                     }
                     startPos.X += tickLabelStep;
                 }

--- a/src/PdfSharp.Charting/Charting.Renderers/HorizontalXAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/HorizontalXAxisRenderer.cs
@@ -96,6 +96,11 @@ namespace PdfSharp.Charting.Renderers
                         {
                             string tickLabel = xv._value;
                             XSize valueSize = _rendererParms.Graphics.MeasureString(tickLabel, xari.TickLabelsFont);
+
+                            XRect rect = new XRect(new XPoint(0, 0), valueSize);
+                            rect.Transform(RotateByDegrees(xari._axis.TickLabelAngle, rect.Center));
+                            valueSize = rect.Size;
+
                             size.Height = Math.Max(valueSize.Height, size.Height);
                             size.Width += valueSize.Width;
                         }
@@ -144,7 +149,8 @@ namespace PdfSharp.Charting.Renderers
                         string tickLabel = xv._value;
                         XSize size = gfx.MeasureString(tickLabel, xari.TickLabelsFont);
                         XPoint point = new XPoint(startPos.X - size.Width / 2, startPos.Y);
-                        DrawTickLabel(gfx, tickLabel, point, size, xari);
+                        
+                        XRect bounds = DrawTickLabel(gfx, tickLabel, point, size, xari);
                     }
                     startPos.X += tickLabelStep;
                 }

--- a/src/PdfSharp.Charting/Charting.Renderers/HorizontalXAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/HorizontalXAxisRenderer.cs
@@ -143,11 +143,8 @@ namespace PdfSharp.Charting.Renderers
                     {
                         string tickLabel = xv._value;
                         XSize size = gfx.MeasureString(tickLabel, xari.TickLabelsFont);
-                        var point = new XPoint(startPos.X - size.Width / 2, startPos.Y);
-                        double rotateAngle = xari._axis.TickLabelAngle;
-                        gfx.RotateAtTransform(rotateAngle, point);
-                        gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, point);
-                        gfx.RotateAtTransform(-rotateAngle, point);
+                        XPoint point = new XPoint(startPos.X - size.Width / 2, startPos.Y);
+                        DrawTickLabel(gfx, tickLabel, point, size, xari);
                     }
                     startPos.X += tickLabelStep;
                 }

--- a/src/PdfSharp.Charting/Charting.Renderers/VerticalXAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/VerticalXAxisRenderer.cs
@@ -129,11 +129,8 @@ namespace PdfSharp.Charting.Renderers
                     XValue xv = xs[idx];
                     string tickLabel = xv._value;
                     XSize size = gfx.MeasureString(tickLabel, xari.TickLabelsFont);
-                    var point = new XPoint(startPos.X - size.Width, startPos.Y + size.Height / 2);
-                    double rotateAngle = xari._axis.TickLabelAngle;
-                    gfx.RotateAtTransform(rotateAngle, point);
-                    gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, point);
-                    gfx.RotateAtTransform(-rotateAngle, point);
+                    XPoint point = new XPoint(startPos.X - size.Width, startPos.Y + size.Height / 2);
+                    DrawTickLabel(gfx, tickLabel, point, size, xari);
                     startPos.Y += tickLabelStep;
                 }
             }

--- a/src/PdfSharp.Charting/Charting.Renderers/VerticalXAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/VerticalXAxisRenderer.cs
@@ -129,7 +129,11 @@ namespace PdfSharp.Charting.Renderers
                     XValue xv = xs[idx];
                     string tickLabel = xv._value;
                     XSize size = gfx.MeasureString(tickLabel, xari.TickLabelsFont);
-                    gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, startPos.X - size.Width, startPos.Y + size.Height / 2);
+                    var point = new XPoint(startPos.X - size.Width, startPos.Y + size.Height / 2);
+                    double rotateAngle = xari._axis.TickLabelAngle;
+                    gfx.RotateAtTransform(rotateAngle, point);
+                    gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, point);
+                    gfx.RotateAtTransform(-rotateAngle, point);
                     startPos.Y += tickLabelStep;
                 }
             }

--- a/src/PdfSharp.Charting/Charting.Renderers/VerticalXAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/VerticalXAxisRenderer.cs
@@ -130,8 +130,9 @@ namespace PdfSharp.Charting.Renderers
                     string tickLabel = xv._value;
                     XSize size = gfx.MeasureString(tickLabel, xari.TickLabelsFont);
                     XPoint point = new XPoint(startPos.X - size.Width, startPos.Y + size.Height / 2);
-                    DrawTickLabel(gfx, tickLabel, point, size, xari);
                     startPos.Y += tickLabelStep;
+
+                    XRect bounds = DrawTickLabel(gfx, tickLabel, point, size, xari);
                 }
             }
 

--- a/src/PdfSharp.Charting/Charting.Renderers/XAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/XAxisRenderer.cs
@@ -27,6 +27,8 @@
 // DEALINGS IN THE SOFTWARE.
 #endregion
 
+using PdfSharp.Drawing;
+
 namespace PdfSharp.Charting.Renderers
 {
     /// <summary>
@@ -47,6 +49,15 @@ namespace PdfSharp.Charting.Renderers
         protected override string GetDefaultTickLabelsFormat()
         {
             return "0";
+        }
+
+        protected void DrawTickLabel(XGraphics gfx, string tickLabel, XPoint point, XSize size, AxisRendererInfo xari)
+        {
+            XRect labelArea = new XRect(point, size);
+            double rotateAngle = xari._axis.TickLabelAngle;
+            gfx.RotateAtTransform(rotateAngle, labelArea.Center);
+            gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, point);
+            gfx.RotateAtTransform(-rotateAngle, labelArea.Center);
         }
     }
 }

--- a/src/PdfSharp.Charting/Charting.Renderers/XAxisRenderer.cs
+++ b/src/PdfSharp.Charting/Charting.Renderers/XAxisRenderer.cs
@@ -51,13 +51,28 @@ namespace PdfSharp.Charting.Renderers
             return "0";
         }
 
-        protected void DrawTickLabel(XGraphics gfx, string tickLabel, XPoint point, XSize size, AxisRendererInfo xari)
+        protected XMatrix RotateByDegrees(double rotateAngle, XPoint center)
+        {
+            double rotateRadians = rotateAngle * System.Math.PI / 180;
+            XMatrix transformation = XMatrix.Identity;
+            transformation.RotateAtPrepend(rotateRadians, center);
+            return transformation;
+        }
+
+        protected XRect DrawTickLabel(XGraphics gfx, string tickLabel, XPoint point, XSize size, AxisRendererInfo xari)
         {
             XRect labelArea = new XRect(point, size);
             double rotateAngle = xari._axis.TickLabelAngle;
+
+            // Draw rotated text.
             gfx.RotateAtTransform(rotateAngle, labelArea.Center);
             gfx.DrawString(tickLabel, xari.TickLabelsFont, xari.TickLabelsBrush, point);
             gfx.RotateAtTransform(-rotateAngle, labelArea.Center);
+
+            // Simulate rotation to get the rotated bounding box
+            var transformation = RotateByDegrees(rotateAngle, labelArea.Center);
+            labelArea.Transform(transformation);
+            return labelArea;
         }
     }
 }

--- a/src/PdfSharp.Charting/Charting/Axis.cs
+++ b/src/PdfSharp.Charting/Charting/Axis.cs
@@ -181,6 +181,13 @@ namespace PdfSharp.Charting
         }
         internal TickLabels _tickLabels;
 
+        public double TickLabelAngle
+        {
+            get { return _tickLabelAngle; }
+            set { _tickLabelAngle = value; }
+        }
+        internal double _tickLabelAngle = 0;
+
         /// <summary>
         /// Gets the format of the axis line.
         /// </summary>

--- a/src/PdfSharp.Charting/PdfSharp.Charting.csproj
+++ b/src/PdfSharp.Charting/PdfSharp.Charting.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PdfSharp</RootNamespace>
     <AssemblyName>PdfSharp.Charting</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -25,6 +25,7 @@
     <DefineConstants>TRACE;DEBUG;CORE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\PdfSharp.Charting.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>

--- a/src/PdfSharp/PdfSharp.csproj
+++ b/src/PdfSharp/PdfSharp.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PdfSharp</RootNamespace>
     <AssemblyName>PdfSharp</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>


### PR DESCRIPTION
I've added the property PdfSharp.Charting.Axis.TickLabelAngle which is used by the renderer to rotate the axis tick labels. For example this creates a counterclockwise 30° slant:
`lineChart.XAxis.TickLabelAngle = -30;`

![image](https://user-images.githubusercontent.com/4007293/64875579-b04a5c80-d64d-11e9-97bd-4b872674ec3c.png)
