### PR TITLE
Optimize resources while importing pages

### DIFF
--- a/src/PdfSharp/Pdf/PdfDictionary.cs
+++ b/src/PdfSharp/Pdf/PdfDictionary.cs
@@ -32,6 +32,7 @@ using System.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using PdfSharp.Drawing;
@@ -1507,7 +1508,12 @@ namespace PdfSharp.Pdf
             /// </summary>
             public void CopyTo(KeyValuePair<string, PdfItem>[] array, int arrayIndex)
             {
-                throw new NotImplementedException();
+                var elements = _elements.ToArray();
+
+                for (int i = arrayIndex; i < Math.Min(array.Length, elements.Length); i++)
+                {
+                    array[i] = elements[i];
+                }
             }
 
             /// <summary>


### PR DESCRIPTION
We came across a PDF file that was referencing one resource dictionary from every page, which contained all fonts and images. Therefore, extracting a single page would make the resulting file very large, as all fonts and images would be embedded as well. We can provide this file for tests, if desired.

The code changes not treat cloning the resource dictionary differently from cloning other objects, as the resources will be reduced to resources used in the content.

There are a few questions open:

- Are there (maybe indirect) ways to reference a resource from the content that are not considered here?
- Is there a way to re-use the lexer/parser to go identify used resources? (currently, this is a rather hacky implementation)
- Are there any points that we have not considered properly here?

Any feedback is greatly appreciated and we'd love to see this ability in the main branch at some point.