### PR TITLE
Avoid "Non-negative number required" Exception

### DIFF
--- a/src/PdfSharp/Pdf.IO/Parser.cs
+++ b/src/PdfSharp/Pdf.IO/Parser.cs
@@ -189,8 +189,8 @@ namespace PdfSharp.Pdf.IO
                     break;
 
                 // Acrobat 6 Professional proudly presents: The Null object!
-                // Even with a one-digit object number an indirect reference «x 0 R» to this object is
-                // one character larger than the direct use of «null». Probable this is the reason why
+                // Even with a one-digit object number an indirect reference Â«x 0 RÂ» to this object is
+                // one character larger than the direct use of Â«nullÂ». Probable this is the reason why
                 // it is true that Acrobat Web Capture 6.0 creates this object, but obviously never 
                 // creates a reference to it!
                 case Symbol.Null:
@@ -1025,10 +1025,10 @@ namespace PdfSharp.Pdf.IO
                 // If "startxref" was still not found yet, read the file completely.
                 string trail = _lexer.ReadRawString(0, length);
                 idx = trail.LastIndexOf("startxref", StringComparison.Ordinal);
+                if (idx == -1)
+                    throw new Exception("The StartXRef table could not be found, the file cannot be opened.");
                 _lexer.Position = idx;
             }
-            if (idx == -1)
-                throw new Exception("The StartXRef table could not be found, the file cannot be opened.");
 
             ReadSymbol(Symbol.StartXRef);
             _lexer.Position = ReadInteger();
@@ -1237,7 +1237,7 @@ namespace PdfSharp.Pdf.IO
             int prev = xrefStream.Elements.GetInteger(PdfCrossReferenceStream.Keys.Prev);
             PdfArray w = (PdfArray)xrefStream.Elements.GetValue(PdfCrossReferenceStream.Keys.W);
 
-            // E.g.: W[1 2 1] ¤ Index[7 12] ¤ Size 19
+            // E.g.: W[1 2 1] Â¤ Index[7 12] Â¤ Size 19
 
             // Setup subsections.
             int subsectionCount;


### PR DESCRIPTION
_lexer.Position = -1 cause System.IO.MemoryStream.set_Position to be -1.
https://imgur.com/a/hy8TKdu