### PR TITLE
Fixes page count calculation, in DoSave, for PDFs opened without Modify so that they may be saved to another location.

### DIFF
--- a/src/PdfSharp/Pdf.Advanced/PdfCatalog.cs
+++ b/src/PdfSharp/Pdf.Advanced/PdfCatalog.cs
@@ -210,9 +210,19 @@ namespace PdfSharp.Pdf.Advanced
         /// </summary>
         internal override void PrepareForSave()
         {
+            var pages = _pages;
+            //We need the pages when saving but they are available only when CanModify yet when Pages is populated, the ability to modify may become possible even when !CanModify.
+            //By using a local copy of PdfPages, we can switch to an unexposed copy during !CanModify.
+            if (!Owner.CanModify && _pages == null)
+            {
+                pages = (PdfPages)Elements.GetValue(Keys.Pages, VCF.CreateIndirect);
+                if (Owner.IsImported)
+                    pages.FlattenPageTree();
+            }
+
             // Prepare pages.
-            if (_pages != null)
-                _pages.PrepareForSave();
+            if (pages != null)
+                pages.PrepareForSave();
 
             // Create outline objects.
             if (_outline != null && _outline.Outlines.Count > 0)

--- a/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/PdfSharp/Pdf/PdfDocument.cs
@@ -603,7 +603,7 @@ namespace PdfSharp.Pdf
         {
             get { return _fullPath; }
         }
-        internal string _fullPath = String.Empty; // TODO: make private and add a setter. public string FullPath { get; set; } = string.Empty;
+        internal string _fullPath = String.Empty; // TODO: make private and add a setter. public string FullPath { get; internal set; } = string.Empty;
 
         /// <summary>
         /// Gets a Guid that uniquely identifies this instance of PdfDocument.
@@ -925,7 +925,7 @@ namespace PdfSharp.Pdf
         }
 
         //The use of an underscore is typically reserved for class-level private variables yet these are set as internal. Property accessors are more appropriate.
-        //TODO: Switch these over to properties. public PdfTrailer Trailer { get; set; }
+        //TODO: Switch these over to properties. internal PdfTrailer Trailer { get; set; }
         internal PdfTrailer _trailer;
         internal PdfCrossReferenceTable _irefTable;
         internal Stream _outStream;


### PR DESCRIPTION
Fixes page count calculation, in DoSave, for PDFs opened without Modify so that they may be saved to another location.