### PR TITLE
Making PDFSharp Compatible With .Net Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # PDFSharpCoreOpt 
 
-#### PDFSharpCoreOpt is a for
-ked Version of PDFSharp , this version is compatible with .net Core 
+#### PDFSharpCoreOpt 
+
+This is modified  Version of PDFSharp , this version is compatible with .net Core 
+
+With this package you can create or modify PDFs with well positioned strings and Images 
 
 
 ## How To Install ?

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Install-Package PdfSharpCoreOpt -Version 1.0.0
 
 ## Sample Code 
 
- static void Main(string[] args)
+ 
+ 
+        static void Main(string[] args)
         {
- PdfDocument pdf = new PdfDocument();
+         PdfDocument pdf = new PdfDocument();
             pdf.Info.Title = "My First PDF";
             //Loop to create Number of Pages 
             for (int i = 0; i < 500; i++)
@@ -41,5 +43,4 @@ Install-Package PdfSharpCoreOpt -Version 1.0.0
 
             string pdfFilename = "My First PDF.pdf";
             pdf.Save(pdfFilename);
-
-}
+            }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,45 @@
-# PDFsharp
-A .NET library for processing PDF
+# PDFSharpCoreOpt 
 
-# Resources
-
-
+#### PDFSharpCoreOpt is a for
+ked Version of PDFSharp , this version is compatible with .net Core 
 
 
+## How To Install ?
+
+With Package Manager install the Nuget package 
+```
+Install-Package PdfSharpCoreOpt -Version 1.0.0 
+```
 
 
 
+## Sample Code 
 
+ static void Main(string[] args)
+        {
+ PdfDocument pdf = new PdfDocument();
+            pdf.Info.Title = "My First PDF";
+            //Loop to create Number of Pages 
+            for (int i = 0; i < 500; i++)
+            {
+                PdfPage pdfPage = pdf.AddPage();
+                XGraphics graph = XGraphics.FromPdfPage(pdfPage);
+                
+                //Specify your Font 
+                XFont font = new XFont("Amiri", 5, XFontStyle.Regular);
+                
+
+                //Position the string you want to Write into the pdf 
+                graph.DrawString("SSSSSSSSS" + i.ToString(), font, XBrushes.Black, new XRect(250, 360, pdfPage.Width.Point, pdfPage.Height.Point), XStringFormats.Center);
+
+                // Insert an image if you want
+                string imageLoc = "test.png"; 
+
+                graph.DrawImage(graph, imageLoc, 535, 700, 50, 50);//Specify the image and position it 
+            }
+
+
+            string pdfFilename = "My First PDF.pdf";
+            pdf.Save(pdfFilename);
+
+}

--- a/README.md
+++ b/README.md
@@ -3,33 +3,10 @@ A .NET library for processing PDF
 
 # Resources
 
-The official project web site:  
-http://pdfsharp.net/
-
-The official peer-to-peer support forum:  
-http://forum.pdfsharp.net/
-
-# Release Notes for PDFsharp/MigraDoc 1.50 (stable)
-
-The stable version of PDFsharp 1.32 was published in 2013.  
-So a new stable version is long overdue.
-
-I really hope the stable version does not have any regressions versus 1.50 beta 3b or later.
-
-And I hope there are no regressions versus version 1.32 stable. But several bugs have been fixed.  
-There are a few breaking changes that require code updates.
-
-To use PDFsharp with Medium Trust you have to get the source code and make some changes. The NuGet packages do not support Medium Trust.  
-Azure servers do not require Medium Trust.
-
-I'm afraid that many users who never tried any beta version of PDFsharp 1.50 will now switch from version 1.32 stable to version 1.50 stable.  
-Nothing wrong about that. I hope we don't get an avalanche of bug reports now.
 
 
-# Which Version to Get?
 
-The naming convention for the packages has changed.
 
-If you are using "PdfSharp -Version 1.32.3057" then the version you need now is "PDFsharp-gdi -Version 1.50".  
-Or get the corresponding package " PDFsharp-MigraDoc-GDI -Version 1.50".
+
+
 

--- a/src/PdfSharp/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharp/Pdf.Internal/PdfEncoders.cs
@@ -70,7 +70,7 @@ namespace PdfSharp.Pdf.Internal
                 {
 #if !SILVERLIGHT && !NETFX_CORE && !UWP
                     // Use .net encoder if available.
-                    _winAnsiEncoding = Encoding.GetEncoding(1252);
+                    _winAnsiEncoding = Encoding.ASCII;
 #else
                     // Use own implementation in Silverlight and WinRT
                     _winAnsiEncoding = new AnsiEncoding();


### PR DESCRIPTION
I Made The PDFSharp Compatible With .Net Core it throw an exception because some Encoding ALgorithms are missing from .Net Core ( 1252 Encoding ) So I Used ASCII Encoding Which is Compatible With .Net core 