### PR TITLE
Adds support for documents with version 0.0

### DIFF
--- a/src/PdfSharp/Drawing/XImage.cs
+++ b/src/PdfSharp/Drawing/XImage.cs
@@ -340,7 +340,7 @@ namespace PdfSharp.Drawing
         /// <param name="path">The path to a BMP, PNG, GIF, JPEG, TIFF, or PDF file.</param>
         public static XImage FromFile(string path)
         {
-            if (PdfReader.TestPdfFile(path) > 0)
+            if (PdfReader.TestPdfFile(path) >= 0)
                 return new XPdfForm(path);
             return new XImage(path);
         }
@@ -355,7 +355,7 @@ namespace PdfSharp.Drawing
             if (stream == null)
                 throw new ArgumentNullException("stream");
 
-            if (PdfReader.TestPdfFile(stream) > 0)
+            if (PdfReader.TestPdfFile(stream) >= 0)
                 return new XPdfForm(stream);
             return new XImage(stream);
         }
@@ -442,7 +442,7 @@ namespace PdfSharp.Drawing
             //if (path.StartsWith("base64:")) // The Image is stored in the string here, so the file exists.
             //    return true;
 
-            if (PdfReader.TestPdfFile(path) > 0)
+            if (PdfReader.TestPdfFile(path) >= 0)
                 return true;
 #if !NETFX_CORE && !UWP
             return File.Exists(path);

--- a/src/PdfSharp/Drawing/XPdfForm.cs
+++ b/src/PdfSharp/Drawing/XPdfForm.cs
@@ -70,7 +70,7 @@ namespace PdfSharp.Drawing
                 throw new FileNotFoundException(PSSR.FileNotFound(path));
 #endif
 
-            if (PdfReader.TestPdfFile(path) == 0)
+            if (PdfReader.TestPdfFile(path) == -1)
                 throw new ArgumentException("The specified file has no valid PDF file header.", "path");
 
             _path = path;
@@ -87,7 +87,7 @@ namespace PdfSharp.Drawing
             // Create a dummy unique path
             _path = "*" + Guid.NewGuid().ToString("B");
 
-            if (PdfReader.TestPdfFile(stream) == 0)
+            if (PdfReader.TestPdfFile(stream) == -1)
                 throw new ArgumentException("The specified stream has no valid PDF file header.", "stream");
 
             _externalDocument = PdfReader.Open(stream);

--- a/src/PdfSharp/Pdf.IO/PdfReader.cs
+++ b/src/PdfSharp/Pdf.IO/PdfReader.cs
@@ -68,7 +68,7 @@ namespace PdfSharp.Pdf.IO
         /// Determines whether the file specified by its path is a PDF file by inspecting the first eight
         /// bytes of the data. If the file header has the form «%PDF-x.y» the function returns the version
         /// number as integer (e.g. 14 for PDF 1.4). If the file header is invalid or inaccessible
-        /// for any reason, 0 is returned. The function never throws an exception. 
+        /// for any reason, -1 is returned. The function never throws an exception.
         /// </summary>
         public static int TestPdfFile(string path)
         {
@@ -107,14 +107,14 @@ namespace PdfSharp.Pdf.IO
                 }
             }
 #endif
-            return 0;
+            return -1;
         }
 
         /// <summary>
         /// Determines whether the specified stream is a PDF file by inspecting the first eight
         /// bytes of the data. If the data begins with «%PDF-x.y» the function returns the version
         /// number as integer (e.g. 14 for PDF 1.4). If the data is invalid or inaccessible
-        /// for any reason, 0 is returned. The function never throws an exception. 
+        /// for any reason, -1 is returned. The function never throws an exception.
         /// </summary>
         public static int TestPdfFile(Stream stream)
         {
@@ -138,14 +138,14 @@ namespace PdfSharp.Pdf.IO
                 // ReSharper disable once EmptyGeneralCatchClause
                 catch { }
             }
-            return 0;
+            return -1;
         }
 
         /// <summary>
         /// Determines whether the specified data is a PDF file by inspecting the first eight
         /// bytes of the data. If the data begins with «%PDF-x.y» the function returns the version
         /// number as integer (e.g. 14 for PDF 1.4). If the data is invalid or inaccessible
-        /// for any reason, 0 is returned. The function never throws an exception. 
+        /// for any reason, -1 is returned. The function never throws an exception.
         /// </summary>
         public static int TestPdfFile(byte[] data)
         {
@@ -168,14 +168,14 @@ namespace PdfSharp.Pdf.IO
                     {
                         char major = header[ich + 4];
                         char minor = header[ich + 6];
-                        if (major >= '1' && major < '2' && minor >= '0' && minor <= '9')
+                        if (major >= '0' && major < '2' && minor >= '0' && minor <= '9')
                             return (major - '0') * 10 + (minor - '0');
                     }
                 }
             }
             // ReSharper disable once EmptyGeneralCatchClause
             catch { }
-            return 0;
+            return -1;
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace PdfSharp.Pdf.IO
                 stream.Position = 0;
                 stream.Read(header, 0, 1024);
                 document._version = GetPdfFileVersion(header);
-                if (document._version == 0)
+                if (document._version == -1)
                     throw new InvalidOperationException(PSSR.InvalidPdf);
 
                 document._irefTable.IsUnderConstruction = true;


### PR DESCRIPTION
Fixes https://github.com/empira/PDFsharp/issues/142

* Changes GetPdfFileVersion to return `-1` not `0` for failure cases
* Changes `TestPdfFile` and all its usages to be aware of this `-1` 
* Changes the check in the only other spot that uses `GetPdfFileVersion`

Let me know if I missed anything. I verified that it is successfully able to open the PDF from the issue with this change.