### PR TITLE
Encrypt hex literals when needed

### DIFF
--- a/src/PdfSharp/Pdf.Internal/PdfEncoders.cs
+++ b/src/PdfSharp/Pdf.Internal/PdfEncoders.cs
@@ -398,6 +398,7 @@ namespace PdfSharp.Pdf.Internal
                 }
                 else
                 {
+                    securityHandler?.EncryptBytes(bytes);
                     pdf.Append('<');
                     for (int idx = 0; idx < count; idx++)
                         pdf.AppendFormat("{0:X2}", bytes[idx]);


### PR DESCRIPTION
Hex literal strings werent getting encrypted so it would break images with indexed colorspace.

Sample program:

```
using System;
using PdfSharp.Pdf;
using PdfSharp.Pdf.IO;

class Program
{
    static void Main()
    {
        var ts = (DateTime.Now - new DateTime(1970, 1, 1)).TotalMilliseconds;

        using (var targetDoc = new PdfDocument())
        {
            using (var src = PdfReader.Open("test.pdf", PdfDocumentOpenMode.Import))
            {
                for (var i = 0; i < src.PageCount; i++)
                {
                    targetDoc.AddPage(src.Pages[i]);
                }
            }

            targetDoc.Save($"out1-{ts:F0}.pdf");

            targetDoc.SecuritySettings.UserPassword = "1234";

            targetDoc.Save($"out2-{ts:F0}.pdf");
        }

        // round trip test
        using (var targetDoc = new PdfDocument())
        {
            using (var src = PdfReader.Open($"out2-{ts:F0}.pdf", "1234", PdfDocumentOpenMode.Import))
            {
                for (var i = 0; i < src.PageCount; i++)
                {
                    targetDoc.AddPage(src.Pages[i]);
                }
            }

            targetDoc.Save($"out5-{ts:F0}.pdf");
        }
    }
}
```

PDF used for testing [test.pdf](https://github.com/empira/PDFsharp/files/8097337/test.pdf)

Output would become this without this PR: [out2-1645190757122.pdf](https://github.com/empira/PDFsharp/files/8097340/out2-1645190757122.pdf) (password 1234)