### PR TITLE
correctly dispose File Stream

### DIFF
--- a/src/PdfSharp/Pdf/PdfDocument.cs
+++ b/src/PdfSharp/Pdf/PdfDocument.cs
@@ -170,6 +170,9 @@ namespace PdfSharp.Pdf
                 if (disposing)
                 {
                     // Dispose managed resources.
+                    if(_outStream != null) {
+                        ((IDisposable)_outStream).Dispose();
+                    } 
                 }
                 //PdfDocument.Gob.DetatchDocument(Handle);
             }


### PR DESCRIPTION
If a Document is created but no pages are added the document object cannot be released as the filestream keeps the partial created file locked.  By disposing the filestream in the dispose method we release the lock on the file.